### PR TITLE
Makefile: Change variable LDFLAGS to LDLIBS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TARGET = doh
 OBJS = doh.o
-LDFLAGS = -lcurl
+LDLIBS = -lcurl
 CFLAGS = -W -Wall -pedantic -g
 
 $(TARGET): $(OBJS)


### PR DESCRIPTION
LDFLAGS is used for flags but LDLIBS is used to specify libraries.
Without this, the program does not compile on Linux
because of the wrong order of the library (-lcurl) on the compilation line.

The wrong order follows. `-lcurl` was placed early because it was an LDFLAG.

    cc -lcurl  doh.o   -o doh

The bad order causes the following errors:
```

doh.o: In function `initprobe':
/home/ubuntu/doh/parts/my-part/build/doh.c:635: undefined reference to `curl_easy_init'
/home/ubuntu/doh/parts/my-part/build/doh.c:653: undefined reference to `curl_easy_setopt'
/home/ubuntu/doh/parts/my-part/build/doh.c:654: undefined reference to `curl_easy_setopt'
/home/ubuntu/doh/parts/my-part/build/doh.c:655: undefined reference to `curl_easy_setopt'

```

More about the order issue, http://www.network-theory.co.uk/docs/gccintro/gccintro_18.html