### PR TITLE
Accept: application/dns-message

### DIFF
--- a/doh.c
+++ b/doh.c
@@ -738,6 +738,8 @@ int main(int argc, char **argv)
   /* use the older content-type */
   headers = curl_slist_append(NULL,
                               "Content-Type: application/dns-message");
+  headers = curl_slist_append(headers,
+                              "Accept: application/dns-message");
 
   /* init a multi stack */
   multi = curl_multi_init();


### PR DESCRIPTION
It may be helpful to send an `Accept` header so DOH servers can distinguish DOH requests from regular traffic.

> The DoH client SHOULD include an HTTP "Accept" request header field
> to indicate what type of content can be understood in response.

https://tools.ietf.org/html/draft-ietf-doh-dns-over-https-14#section-4.1

*Edit:* My use case for this patch is to support https://github.com/qoelet/playdoh which currently expects the `Accept` header.