### PR TITLE
add -t for test mode. this limits us to one upstream query (AAAA), and

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TARGET = doh
 OBJS = doh.o
-LDLIBS = -lcurl
-CFLAGS = -W -Wall -pedantic -g
+LDLIBS = `curl-config --libs`
+CFLAGS = -W -Wall -pedantic -g `curl-config --cflags`
 
 $(TARGET): $(OBJS)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ servers](https://github.com/curl/curl/wiki/DNS-over-HTTPS#publicly-available-ser
 Options:
 
 - `-h` shows help output
+- `-t` enables server test mode
 - `-v` enables verbose mode
 
 ## Examples


### PR DESCRIPTION
prints no output.

look at QR bit to ensure that the answer we received was a response.

do not treat empty answers (no records of that type) as errors.

exit status is now nonzero for usage errors.

exit status is now nonzero if there is no evidence of a DoH service
at the given URI.

Makefile uses curl-config to find -I and -L values.