### PR TITLE
Added an option and fixed a bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+doh

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Options:
 - `-h` shows help output
 - `-t` enables server test mode
 - `-v` enables verbose mode
-- `-i` enables insecure mode, skipping server certificate validation
+- `-k` enables insecure mode, skipping server certificate validation
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Options:
 - `-h` shows help output
 - `-t` enables server test mode
 - `-v` enables verbose mode
+- `-i` enables insecure mode, skipping server certificate validation
 
 ## Examples
 

--- a/doh.c
+++ b/doh.c
@@ -620,7 +620,7 @@ struct dnsprobe {
 
 static int initprobe(struct dnsprobe *p, int dnstype, char *host,
                      const char *url, CURLM *multi, int trace_enabled,
-                     struct curl_slist *headers)
+                     struct curl_slist *headers, long insecure_mode)
 {
   CURL *curl;
   p->dohlen = doh_encode(host, dnstype, p->dohbuffer, sizeof(p->dohbuffer));
@@ -666,6 +666,8 @@ static int initprobe(struct dnsprobe *p, int dnstype, char *host,
     curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
     curl_easy_setopt(curl, CURLOPT_PRIVATE, p);
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, insecure_mode);
+
     p->curl = curl;
 
     /* add the individual transfers */
@@ -692,7 +694,8 @@ static void help(void)
           "Usage: doh [options] <host> [URL]\n"
           "  -h  this help\n"
           "  -t  test mode\n"
-          "  -v  verbose mode\n");
+          "  -v  verbose mode\n"
+          "  -i  insecure mode - don't validate TLS certificate\n" );
   exit(1);
 }
 
@@ -714,6 +717,7 @@ int main(int argc, char **argv)
   int exit_status = 0;
   int queued;
   int url_argc = 1;
+  long insecure_mode = 1L;
 
   if(argc > 1) {
     char *opts = argv[1];
@@ -726,6 +730,9 @@ int main(int argc, char **argv)
           break;
         case 't':
           test_mode = 1;
+          break;
+        case 'i':
+          insecure_mode = 0L;
           break;
         case 'h':
           help();
@@ -754,9 +761,9 @@ int main(int argc, char **argv)
 
   doh_init(&d);
   if(!test_mode) {
-    initprobe(&probe[0], DNS_TYPE_A, host, url, multi, trace_enabled, headers);
+    initprobe(&probe[0], DNS_TYPE_A, host, url, multi, trace_enabled, headers, insecure_mode);
   }
-  initprobe(&probe[1], DNS_TYPE_AAAA, host, url, multi, trace_enabled, headers);
+  initprobe(&probe[1], DNS_TYPE_AAAA, host, url, multi, trace_enabled, headers, insecure_mode);
 
   /* we start some action by calling perform right away */
   curl_multi_perform(multi, &still_running);

--- a/doh.c
+++ b/doh.c
@@ -696,7 +696,7 @@ static void help(void)
           "  -h  this help\n"
           "  -t  test mode\n"
           "  -v  verbose mode\n"
-          "  -i  insecure mode - don't validate TLS certificate\n" );
+          "  -k  insecure mode - don't validate TLS certificate\n" );
   exit(1);
 }
 

--- a/doh.c
+++ b/doh.c
@@ -722,8 +722,7 @@ int main(int argc, char **argv)
   if(argc > 1) {
     char *opts = argv[1];
     if(opts[0] == '-') {
-      do {
-        opts++;
+      while(*++opts) {
         switch(*opts) {
         case 'v':
           trace_enabled = 1;
@@ -735,6 +734,7 @@ int main(int argc, char **argv)
           insecure_mode = 0L;
           break;
         case 'h':
+        default:
           help();
           break;
         }
@@ -744,6 +744,10 @@ int main(int argc, char **argv)
   }
   else
     help();
+
+  if(url_argc>=argc)
+    help();
+
   host = argv[url_argc];
   if(argc > 1 + url_argc)
     url = argv[url_argc + 1];


### PR DESCRIPTION
I discovered your tool while looking for a way to quickly test DoH interactions with some network security products I work with. It was just what I needed - super simple and effective. Thanks for creating it.

I found it useful to have an option to run in an 'insecure' mode while testing, skipping validation of the server cert so that I could use a self-signed cert or run it through an SSL-decrypting middlebox.

I also came across a bug where the tool would segfault if you entered an unrecognized command line option and no hostname to look up, which was due to a bounds checking error - failure to check the incremented url_argc against argc before attempting to read the non-existent argv.

Finally I added 'doh' to git-ignore, which is the name of the built executable on Mac or Linux.

I hope you find these changes useful. I'm not hugely experienced with GitHub, so I hope I've gone about this the right way.