### PR TITLE
doh: fix segfault - do not pass host as NULL pointer to initprobe()

### DIFF
--- a/doh.c
+++ b/doh.c
@@ -738,6 +738,8 @@ int main(int argc, char **argv)
   else
     help();
   host = argv[url_argc];
+  if (host == NULL)
+    help();
   if(argc > 1 + url_argc)
     url = argv[url_argc + 1];
 


### PR DESCRIPTION
This path fixes a segfault triggered out as following:

openbsd-dev$ doh -t
Segmentation fault (core dumped)

