### PR TITLE
doh_encode: fix the comparison for long host names

### DIFF
--- a/doh.c
+++ b/doh.c
@@ -234,7 +234,7 @@ static size_t doh_encode(const char *host,
   unsigned char *orig = dnsp;
   const char *hostp = host;
 
-  if(len < (12 + hostlen + 4))
+  if(len <= (12 + hostlen + 4))
     return DOH_TOO_SMALL_BUFFER;
 
   *dnsp++ = 0; /* 16 bit id */


### PR DESCRIPTION
Otherwise it could cause a single byte buffer overflow on 240 bytes host
names.

Reported-by: Paul Dreik