### PR TITLE
Makefile: add install stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,13 @@ OBJS = doh.o
 LDLIBS = `curl-config --libs`
 CFLAGS = -W -Wall -pedantic -g `curl-config --cflags`
 
+BINDIR ?= /usr/bin
+
 $(TARGET): $(OBJS)
+
+install:
+	install -d $(DESTDIR)$(BINDIR)
+	install -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
 
 clean:
 	rm -f $(OBJS) $(TARGET)


### PR DESCRIPTION
We are now able to install doh as follows:

 $: make install DESTDIR=foo
 install -d foo/usr/bin
 install -m 0755 doh foo/usr/bin

 $: tree foo
 foo
 └── usr
     └── bin
         └── doh