### PR TITLE
Preserve existing CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TARGET = doh
 OBJS = doh.o
 LDLIBS = `curl-config --libs`
-CFLAGS = -W -Wall -pedantic -g `curl-config --cflags`
+CFLAGS := $(CFLAGS) -W -Wall -pedantic -g `curl-config --cflags`
 
 BINDIR ?= /usr/bin
 


### PR DESCRIPTION
This was suggested during the Fedora package review, to allow build system CFLAGS to be appended to rather than replaced.

https://bugzilla.redhat.com/show_bug.cgi?id=1753769#c2