### PR TITLE
doh: Change cmd line options -4 and -6 to specify resolve only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@
 *.idb
 *.pdb
 
+# Visual Studio files
+*.suo
+
 # Kernel Module Compile Results
 *.mod*
 *.cmd

--- a/doh.1
+++ b/doh.1
@@ -25,9 +25,9 @@ Test mode. Returns an exit code if there isn't a proper DoH response.
 Verbose mode. Shows lots of details from the underlying HTTPS connection and
 transfer.
 .IP \-4
-Use only IPv4 transport
+Use only IPv4 transport to DOH server.
 .IP \-6
-Use only IPv6 transport
+Use only IPv6 transport to DOH server.
 .IP "-r NAME:PORT:ADDRESS"
 Provide a fixed IP address for the given host name + port pair. This option
 can be provided several times. This preloads the DNS cache.


### PR DESCRIPTION
Prior to this change -4 and -6 not only specified the IP resolve type
but also the requested records type (ie -4 meant A and -6 meant AAAA).
That is no longer necessary and could conflict since the -tTYPE option
was added.

Follow-up to acc9ab5.

Closes #xxxx

---

This is a follow-up to #27. The bug is for example ` doh -4 -tAAAA google.com` no request would be made due to conflict.

I'm not sure about the CNAME stuff I didn't understand why `if(query_type == 0 || query_type == DNS_TYPE_CNAME)` was needed. Are there test servers?

/cc @jalalmostafa