### PR TITLE
manpage installation fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ $(TARGET): $(OBJS)
 install:
 	install -d $(DESTDIR)$(BINDIR)
 	install -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
-	install -m 0744 $(MANUAL) $(DESTDIR)$(MANDIR)/man1/
+	install -m 0644 $(MANUAL) $(DESTDIR)$(MANDIR)/man1/
 
 clean:
 	rm -f $(OBJS) $(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ $(TARGET): $(OBJS)
 install:
 	install -d $(DESTDIR)$(BINDIR)
 	install -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
+	install -d $(DESTDIR)$(MANDIR)/man1
 	install -m 0644 $(MANUAL) $(DESTDIR)$(MANDIR)/man1/
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ $(TARGET): $(OBJS)
 install:
 	install -d $(DESTDIR)$(BINDIR)
 	install -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
-	install -m 0744 $(MANUAL) $(MANDIR)/man1/
+	install -m 0744 $(MANUAL) $(DESTDIR)$(MANDIR)/man1/
 
 clean:
 	rm -f $(OBJS) $(TARGET)


### PR DESCRIPTION
While working on updating the Fedora doh package, and I noticed a few small problems with the manpage installation.

* DESTDIR is not used like with the binary installation
* manpages don't need execute permission
* missing directory structure can cause failures in an empty DESTDIR (such as during RPM package builds)

I set these up as separate commits, but I'm happy to squash them into one if that is preferred.